### PR TITLE
Fix ScriptEvent data overflow error

### DIFF
--- a/server/src/system.ts
+++ b/server/src/system.ts
@@ -975,7 +975,7 @@ export class InteriorSystem {
         delete data.outsideShape;
         delete data.ipl;
 
-        alt.emitClient(player, INTERIOR_INTERACTIONS.SHOW_MENU, interior, isOutside);
+        alt.emitClient(player, INTERIOR_INTERACTIONS.SHOW_MENU, data, isOutside);
     }
 
     /**


### PR DESCRIPTION
The reduced `data` object was already there, but never used.